### PR TITLE
Improvecompile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ CMakeCache.txt
 CMakeFiles
 build-shared/*
 build-static/*
+build-debug/*
 build/*
 _install/*
 .vscode

--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,9 @@ PLS
 libpls.a
 CMakeCache.txt
 CMakeFiles
-build-shared
-build-static
-_install
+build-shared/*
+build-static/*
+build/*
+_install/*
 .vscode
 cmake_install.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,14 @@
 cmake_minimum_required( VERSION 3.16 )
 
-project(PLS VERSION 2.0.0)
+project(PLS VERSION 2.0.1 LANGUAGES CXX)
 
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+#include(CMakePackageConfigHelpers)
+
+# configure_package_config_file(
+#   "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+#   INSTALL_DESTINATION
+#   ${CMAKE_INSTALL_LIBDIR}/cmake/PLS-${PROJECT_VERSION}
+# )
 
 # TODO need to figure out the right way to ask for MPREAL_SUPPORT
 # would be propogated from parent project, presumably
@@ -10,7 +16,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 # TODO figure out if this is the right way to do this
 # intend: if new enough Eigen3 is found, use it;
 # otherwise, install from submoduled source
-find_package(Eigen3 3.4.90 NO_MODULE)
+find_package(Eigen3 3.4.90)
 
 if (NOT Eigen3_FOUND)
   message(WARNING "Eigen3 3.4.90+ not found; installing from source...")
@@ -31,49 +37,55 @@ endif ()
 
 # include(GenerateExportHeader)
 
-add_library(pls ${CMAKE_CURRENT_SOURCE_DIR}/src/pls.cpp)
-add_library(${CMAKE_PROJECT_NAME}::pls ALIAS pls)
+add_library(PLS ${CMAKE_CURRENT_SOURCE_DIR}/src/pls.cpp)
 
-set_target_properties(pls PROPERTIES
+set_target_properties(PLS PROPERTIES
                       VERSION ${${CMAKE_PROJECT_NAME}_VERSION}
                       SOVERSION ${${CMAKE_PROJECT_NAME}_VERSION_MAJOR})
 
 # generate_export_header(pls)
 
-target_compile_features(pls PUBLIC cxx_std_17)
+target_compile_features(PLS PUBLIC cxx_std_17)
 
 target_compile_definitions(
-  pls PUBLIC "$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:PLS_STATIC_DEFINE>"
+  PLS PUBLIC "$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:PLS_STATIC_DEFINE>"
 )
 
 target_include_directories(
-  pls PUBLIC
+  PLS PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>"
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-  "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+  "$<INSTALL_INTERFACE:include>"
 )
 
-target_link_libraries(pls PUBLIC Eigen3::Eigen)
+target_link_libraries(PLS PUBLIC Eigen3::Eigen)
 
-add_executable( PLS src/main.cpp )
-target_link_libraries( PLS pls )
+add_executable(PLS-bin src/main.cpp)
+target_link_libraries(PLS-bin PLS)
+set_target_properties(PLS-bin PROPERTIES OUTPUT_NAME PLS)
 
-install(TARGETS PLS pls
-  EXPORT plsTargets
-  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+  "PLSConfigVersion.cmake"
+  VERSION ${PLS_VERSION}
+  COMPATIBILITY SameMajorVersion
+)
+install(FILES "PLSConfig.cmake" "${CMAKE_CURRENT_BINARY_DIR}/PLSConfigVersion.cmake"
+  DESTINATION lib/cmake/PLS
+)
+
+install(TARGETS PLS EXPORT PLSTargets
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
   INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
-# if (${CMAKE_INSTALL_INCLUDEDIR})
-#   message(STATUS "CMAKE_INSTALL_INCLUDEDIR: ${CMAKE_INSTALL_INCLUDEDIR}")
-#   install(FILES pls.h types.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-# else()
-#   message(STATUS "CMAKE_INSTALL_INCLUDEDIR not defined")
-# endif()
+install(EXPORT PLSTargets
+  FILE PLSTargets.cmake
+  NAMESPACE PLS::
+  DESTINATION lib/cmake/PLS
+)
 
-install(EXPORT plsTargets
-        FILE plsTargets.cmake
-        NAMESPACE PLS::
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/pls
+install(TARGETS PLS-bin
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,8 @@ if (DEFINED ${CMAKE_PROJECT_NAME}_SHARED_LIBS)
     set(BUILD_SHARED_LIBS "${${CMAKE_PROJECT_NAME}_SHARED_LIBS}")
 endif ()
 
+# include(GenerateExportHeader)
+
 add_library(pls ${CMAKE_CURRENT_SOURCE_DIR}/src/pls.cpp)
 add_library(${CMAKE_PROJECT_NAME}::pls ALIAS pls)
 
@@ -36,14 +38,19 @@ set_target_properties(pls PROPERTIES
                       VERSION ${${CMAKE_PROJECT_NAME}_VERSION}
                       SOVERSION ${${CMAKE_PROJECT_NAME}_VERSION_MAJOR})
 
-target_include_directories(pls PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>")
+# generate_export_header(pls)
 
 target_compile_features(pls PUBLIC cxx_std_17)
 
 target_compile_definitions(
-    pls PUBLIC "$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:PLS_STATIC_DEFINE>")
+  pls PUBLIC "$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:PLS_STATIC_DEFINE>"
+)
+
 target_include_directories(
-    pls PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>")
+  pls PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+)
 
 target_link_libraries(pls PUBLIC Eigen3::Eigen)
 
@@ -51,7 +58,22 @@ add_executable( PLS src/main.cpp )
 target_link_libraries( PLS pls )
 
 install(TARGETS PLS pls
-  RUNTIME DESTINATION bin
-  LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib
+  EXPORT plsTargets
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+# if (${CMAKE_INSTALL_INCLUDEDIR})
+#   message(STATUS "CMAKE_INSTALL_INCLUDEDIR: ${CMAKE_INSTALL_INCLUDEDIR}")
+#   install(FILES pls.h types.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+# else()
+#   message(STATUS "CMAKE_INSTALL_INCLUDEDIR not defined")
+# endif()
+
+install(EXPORT plsTargets
+        FILE plsTargets.cmake
+        NAMESPACE PLS::
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/pls
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,14 +2,6 @@ cmake_minimum_required( VERSION 3.16 )
 
 project(PLS VERSION 2.0.1 LANGUAGES CXX)
 
-#include(CMakePackageConfigHelpers)
-
-# configure_package_config_file(
-#   "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
-#   INSTALL_DESTINATION
-#   ${CMAKE_INSTALL_LIBDIR}/cmake/PLS-${PROJECT_VERSION}
-# )
-
 # TODO need to figure out the right way to ask for MPREAL_SUPPORT
 # would be propogated from parent project, presumably
 
@@ -35,15 +27,12 @@ if (DEFINED ${CMAKE_PROJECT_NAME}_SHARED_LIBS)
     set(BUILD_SHARED_LIBS "${${CMAKE_PROJECT_NAME}_SHARED_LIBS}")
 endif ()
 
-# include(GenerateExportHeader)
-
-add_library(PLS ${CMAKE_CURRENT_SOURCE_DIR}/src/pls.cpp)
+# our library target
+add_library(PLS)
 
 set_target_properties(PLS PROPERTIES
                       VERSION ${${CMAKE_PROJECT_NAME}_VERSION}
                       SOVERSION ${${CMAKE_PROJECT_NAME}_VERSION_MAJOR})
-
-# generate_export_header(pls)
 
 target_compile_features(PLS PUBLIC cxx_std_17)
 
@@ -57,6 +46,14 @@ target_include_directories(
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include>"
 )
+
+target_sources(PLS PRIVATE src/pls.cpp)
+# in 3.23:
+# target_sources(
+#   PLS PUBLIC FILE_SET HEADERS
+#   BASE_DIR "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>" "$<INSTALL_INTERFACE:include>"
+#   FILES PLS/pls.h PLS/types.h
+# )
 
 target_link_libraries(PLS PUBLIC Eigen3::Eigen)
 
@@ -77,8 +74,14 @@ install(FILES "PLSConfig.cmake" "${CMAKE_CURRENT_BINARY_DIR}/PLSConfigVersion.cm
 install(TARGETS PLS EXPORT PLSTargets
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  INCLUDES DESTINATION include
 )
+
+install(DIRECTORY include/PLS
+  DESTINATION include
+)
+# in 3.23:
+# install(TARGETS PLS FILE_SET HEADERS)
 
 install(EXPORT PLSTargets
   FILE PLSTargets.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ add_executable( PLS src/main.cpp )
 target_link_libraries( PLS pls )
 
 install(TARGETS PLS pls
-#  RUNTIME DESTINATION bin
+  RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required( VERSION 3.16 )
 
 project(PLS VERSION 2.0.0)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 # TODO need to figure out the right way to ask for MPREAL_SUPPORT
 # would be propogated from parent project, presumably
 
@@ -9,6 +11,7 @@ project(PLS VERSION 2.0.0)
 # intend: if new enough Eigen3 is found, use it;
 # otherwise, install from submoduled source
 find_package(Eigen3 3.4.90 NO_MODULE)
+
 if (NOT Eigen3_FOUND)
   message(WARNING "Eigen3 3.4.90+ not found; installing from source...")
   include(FetchContent)
@@ -18,7 +21,9 @@ if (NOT Eigen3_FOUND)
     GIT_REPOSITORY https://gitlab.com/libeigen/eigen.git
   )
   FetchContent_MakeAvailable(Eigen3)
-endif(NOT Eigen3_FOUND)
+else()
+  message(STATUS "Eigen3 found: ${Eigen3_VERSION}")
+endif()
 
 if (DEFINED ${CMAKE_PROJECT_NAME}_SHARED_LIBS)
     set(BUILD_SHARED_LIBS "${${CMAKE_PROJECT_NAME}_SHARED_LIBS}")
@@ -46,7 +51,7 @@ add_executable( PLS src/main.cpp )
 target_link_libraries( PLS pls )
 
 install(TARGETS PLS pls
-  RUNTIME DESTINATION bin
+#  RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
 )

--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,18 @@
 
 .FORCE:
 
-build: .FORCE
-	cmake -S . -B $@
-
-build-shared: .FORCE
-	cmake -S . -B $@ -DBUILD_SHARED_LIBS=YES -DCMAKE_BUILD_TYPE=Release
-	cmake --build $@
-
-build-static: .FORCE
-	cmake -S . -B $@ -DBUILD_SHARED_LIBS=NO -DCMAKE_BUILD_TYPE=Release
-	cmake --build $@
-
 # use `make install TESTING="--prefix _install"` to dry run installation
 TESTING ?=
 
 install: build-static build-shared
 	cmake --install build-shared $(TESTING)
 	cmake --install build-static $(TESTING)
+
+build-shared: .FORCE
+	mkdir -p $@ && cd $@ && cmake .. -DBUILD_SHARED_LIBS=YES -DCMAKE_BUILD_TYPE=Release && cmake --build .
+
+build-static: .FORCE
+	mkdir -p $@ && cd $@ && cmake .. -DBUILD_SHARED_LIBS=NO -DCMAKE_BUILD_TYPE=Release && cmake --build .
 
 clean: .FORCE
 	git clean -ifdx

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@
 TESTING ?=
 
 install: build-static build-shared
-	cmake --install build-shared $(TESTING)
-	cmake --install build-static $(TESTING)
+	sudo cmake --install build-shared $(TESTING)
+	sudo cmake --install build-static $(TESTING)
 
 build: .FORCE
 	mkdir -p $@ && cd $@ && cmake ..

--- a/Makefile
+++ b/Makefile
@@ -17,5 +17,11 @@ build-shared: .FORCE
 build-static: .FORCE
 	mkdir -p $@ && cd $@ && cmake .. -DBUILD_SHARED_LIBS=NO -DCMAKE_BUILD_TYPE=Release && cmake --build .
 
+build-debug: .FORCE
+	mkdir -p $@ && cd $@ && cmake .. -DBUILD_SHARED_LIBS=NO -DCMAKE_BUILD_TYPE=Debug && cmake --build .
+
+valgrind: build-debug
+	cd $^ && valgrind --leak-check=yes ./PLS ../toyX.csv ../toyY.csv 2
+
 clean: .FORCE
 	git clean -ifdx

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ install: build-static build-shared
 	cmake --install build-shared $(TESTING)
 	cmake --install build-static $(TESTING)
 
+build: .FORCE
+	mkdir -p $@ && cd $@ && cmake ..
+
 build-shared: .FORCE
 	mkdir -p $@ && cd $@ && cmake .. -DBUILD_SHARED_LIBS=YES -DCMAKE_BUILD_TYPE=Release && cmake --build .
 

--- a/PLSConfig.cmake
+++ b/PLSConfig.cmake
@@ -1,0 +1,3 @@
+include(CMakeFindDependencyMacro)
+find_dependency(Eigen3 3.4.90)
+include("${CMAKE_CURRENT_LIST_DIR}/PLSTargets.cmake")

--- a/include/PLS/pls.h
+++ b/include/PLS/pls.h
@@ -1,36 +1,13 @@
 #ifndef PLS_H
 #define PLS_H
 
-#include <Eigen/Core> // only need to know `Matrix`es exist for header
+#include <PLS/types.h> // only need to know forward declarations for header
+
 #include <vector>
 #include <iostream> // for ostream, std::cerr
 #include <random> // for std::mt19937
 #include <algorithm> // sort
 #include <numeric> // iota
-
-#ifdef MPREAL_SUPPORT
-#include "mpreal.h"
-#include <unsupported/Eigen/MPRealSupport>
-    using namespace mpfr;
-    typedef mpreal float_type;
-    typedef Eigen::Matrix<float_type, Eigen::Dynamic, Eigen::Dynamic> Mat2D;
-    typedef Eigen::Matrix<float_type, Eigen::Dynamic, 1> Col;
-    typedef Eigen::Matrix<float_type, 1, Eigen::Dynamic> Row;
-    typedef Eigen::Matrix<std::complex<float_type>, Eigen::Dynamic, Eigen::Dynamic> Mat2Dc;
-    typedef Eigen::Matrix<std::complex<float_type>, Eigen::Dynamic, 1> Colc;
-#else
-    typedef double float_type;
-    typedef Eigen::MatrixXd Mat2D;
-    typedef Eigen::VectorXd Col;
-    typedef Eigen::RowVectorXd Row;
-    typedef Eigen::MatrixXcd Mat2Dc;
-    typedef Eigen::VectorXcd Colc;
-#endif // MPREAL_SUPPORT
-
-typedef Eigen::VectorXi Coli;
-typedef Eigen::Matrix<size_t, Eigen::Dynamic, 1> Colsz;
-typedef Eigen::RowVectorXi Rowi;
-typedef Eigen::Matrix<size_t, 1, Eigen::Dynamic> Rowsz;
 
 /**
 @brief Namespace for all Partial Least Square (PLS) related functions and classes.
@@ -198,39 +175,39 @@ struct Model {
     // TODO: private? should only be used for cross-validation exercises
     void plsr(const Mat2D &X, const Mat2D &Y, const METHOD &algorithm);
 
+    // the modes below all default to originally-specified number of components
+
     // Transforms X_new into the latent space of the PLS model
     // i.e. the orthogonal X you wish you could measure
     const Mat2Dc scores(const Mat2D &X_new, const size_t comp) const;
-    // default to originally-specified number of components
-    const Mat2Dc scores(const Mat2D &X_new) const { return scores(X_new, A); }
+    const Mat2Dc scores(const Mat2D &X_new) const;
 
     const Mat2Dc loadingsX(const size_t comp) const;
-    const Mat2Dc loadingsX() const { return loadingsX(A); }
-
+    const Mat2Dc loadingsX() const;
     const Mat2Dc loadingsY(const size_t comp) const; 
-    const Mat2Dc loadingsY() const { return loadingsY(A); }
+    const Mat2Dc loadingsY() const;
 
     // compute the regression coefficients (aka 'beta')
     const Mat2Dc coefficients(const size_t comp) const;
-    const Mat2Dc coefficients() const { return coefficients(A); }
+    const Mat2Dc coefficients() const;
 
     // predicted Y values, given X values and pls model
     const Mat2D fitted_values(const Mat2D &X, const size_t comp) const;
-    const Mat2D fitted_values(const Mat2D &X) const { return fitted_values(X, A); }
+    const Mat2D fitted_values(const Mat2D &X) const;
 
     // unexplained portion of Y values
     const Mat2D residuals(const Mat2D &X, const Mat2D &Y, const size_t comp) const;
-    const Mat2D residuals(const Mat2D &X, const Mat2D &Y) const { return residuals(X, Y, A); }
+    const Mat2D residuals(const Mat2D &X, const Mat2D &Y) const;
 
     // Sum of squared errors: uses estimated PLS model on X to predict Y, computes
     // the difference between the predicted and actual Y values, and squares the residual
     // and then sums (by column, the Y components) over all observations
     const Row SSE(const Mat2D &X, const Mat2D &Y, const size_t comp) const;
-    const Row SSE(const Mat2D &X, const Mat2D &Y) const { return SSE(X, Y, A); }
+    const Row SSE(const Mat2D &X, const Mat2D &Y) const;
 
     // fraction of explainable variance
     const Row explained_variance(const Mat2D &X, const Mat2D &Y, const size_t comp) const;
-    const Row explained_variance(const Mat2D &X, const Mat2D &Y) const { return explained_variance(X, Y, A); }
+    const Row explained_variance(const Mat2D &X, const Mat2D &Y) const;
 
     // cross-validation methods:
     //  - LOO: leave-one-out => requires no new data
@@ -247,21 +224,23 @@ struct Model {
 
     void print_state(std::ostream &os = std::cerr) const;
 
+    ~Model();
+
     private:
-        const Mat2D _X, _Y; // hang onto these for certain cross-validation methods
+        const Mat2D &_X, &_Y; // hang onto these for certain cross-validation methods
         size_t A; // number of components
-        Mat2Dc P, W, R, Q, T;
+        Mat2Dc *P, *W, *R, *Q, *T;
         PLS::METHOD method;
 
-        Model(
-            const size_t &num_predictors, const size_t &num_responses,
-            const METHOD &algorithm = KERNEL_TYPE1
-        );
+        // Model(
+        //     const size_t &num_predictors, const size_t &num_responses,
+        //     const METHOD &algorithm = KERNEL_TYPE1
+        // );
 
-        Model(
-            const size_t &num_predictors, const size_t &num_responses,
-            const METHOD &algorithm, const size_t &max_components
-        );
+        // Model(
+        //     const size_t &num_predictors, const size_t &num_responses,
+        //     const METHOD &algorithm, const size_t &max_components
+        // );
 
 };
 

--- a/include/PLS/pls.h
+++ b/include/PLS/pls.h
@@ -3,6 +3,7 @@
 
 #include <PLS/types.h> // only need to know forward declarations for header
 
+#include <memory> // for std::unique_ptr, std::shared_ptr
 #include <vector>
 #include <iostream> // for ostream, std::cerr
 #include <random> // for std::mt19937
@@ -224,8 +225,6 @@ struct Model {
 
     void print_state(std::ostream &os = std::cerr) const;
 
-    ~Model();
-
     private:
         const size_t A; // number of components
         // TYPE * const == the pointer is a const, not the TYPE it points to
@@ -234,11 +233,7 @@ struct Model {
         const Mat2D * const _X;
         const Mat2D * const _Y;
 
-        Mat2Dc * const P;
-        Mat2Dc * const W;
-        Mat2Dc * const R;
-        Mat2Dc * const Q;
-        Mat2Dc * const T;
+        const std::unique_ptr<Mat2Dc> P, W, R, Q, T;
 
         const PLS::METHOD method;
 

--- a/include/PLS/pls.h
+++ b/include/PLS/pls.h
@@ -227,20 +227,31 @@ struct Model {
     ~Model();
 
     private:
-        const Mat2D &_X, &_Y; // hang onto these for certain cross-validation methods
-        size_t A; // number of components
-        Mat2Dc *P, *W, *R, *Q, *T;
-        PLS::METHOD method;
+        const size_t A; // number of components
+        // TYPE * const == the pointer is a const, not the TYPE it points to
 
-        // Model(
-        //     const size_t &num_predictors, const size_t &num_responses,
-        //     const METHOD &algorithm = KERNEL_TYPE1
-        // );
+        // hang onto these for certain cross-validation methods
+        const Mat2D * const _X;
+        const Mat2D * const _Y;
 
-        // Model(
-        //     const size_t &num_predictors, const size_t &num_responses,
-        //     const METHOD &algorithm, const size_t &max_components
-        // );
+        Mat2Dc * const P;
+        Mat2Dc * const W;
+        Mat2Dc * const R;
+        Mat2Dc * const Q;
+        Mat2Dc * const T;
+
+        const PLS::METHOD method;
+
+        // internal constructor for cross-validation methods
+        Model(
+            const size_t &num_predictors, const size_t &num_responses,
+            const METHOD &algorithm = KERNEL_TYPE1
+        );
+
+        Model(
+            const size_t &num_predictors, const size_t &num_responses,
+            const METHOD &algorithm, const size_t &max_components
+        );
 
 };
 

--- a/include/PLS/types.h
+++ b/include/PLS/types.h
@@ -1,0 +1,38 @@
+
+#ifndef PLS_TYPES_H
+#define PLS_TYPES_H
+
+#include <complex>
+
+#ifdef MPREAL_SUPPORT
+#include "mpreal.h"
+    typedef mpfr::mpreal float_type;
+#else
+    typedef double float_type;
+#endif // MPREAL_SUPPORT
+
+// forward declaration of all the Eigen types
+// in dependent code, include this in header files (to forward declare the types)
+// and include <Eigen/Core> in object source files to get e.g. Matrix accessor methods
+namespace Eigen {
+
+    template<typename _Scalar, int _Rows, int _Cols, int _Options, int _MaxRows, int _MaxCols>
+    class Matrix;
+// TODO get this from cmake EIGEN_DEFAULT_DENSE_INDEX_TYPE
+    typedef std::ptrdiff_t Index;
+}
+
+using Mat2D = Eigen::Matrix<float_type, -1, -1, 0, -1, -1>;
+using Mat2Dc = Eigen::Matrix<std::complex<float_type>, -1, -1, 0, -1, -1>;
+
+using Col = Eigen::Matrix<float_type, -1, 1, 0, -1, 1>;
+using Colc = Eigen::Matrix<std::complex<float_type>, -1, 1, 0, -1, 1>;
+using Coli = Eigen::Matrix<int, -1, 1, 0, -1, 1>;
+using Colsz = Eigen::Matrix<size_t, -1, 1, 0, -1, 1>;
+
+// n.b. rows must be _Options = 1, i.e. RowMajor
+using Row = Eigen::Matrix<float_type, 1, -1, 1, 1, -1>;
+using Rowi = Eigen::Matrix<int, 1, -1, 1, 1, -1>;
+using Rowsz = Eigen::Matrix<size_t, 1, -1, 1, 1, -1>;
+
+#endif // PLS_TYPES_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,13 +4,15 @@
 #include <iostream>
 
 #include <PLS/pls.h>
+#include <Eigen/Dense>
 
 using namespace PLS;
 
 int main(int argc, char *argv[]) {
 
     if (argc != 4) { 
-        std::cerr << "Usage: ./pls X_data.csv Y_data.csv num_components" << std::endl;
+        std::cerr << "Usage:" << std::endl;
+        std::cerr << "$ PLS X_data.csv Y_data.csv num_components" << std::endl;
         std::cerr << "NB: X and Y csvs must be comma delimited, square numerical data, with no headers." << std::endl;
         exit(100); 
     }
@@ -18,11 +20,8 @@ int main(int argc, char *argv[]) {
     std::string x_filename(argv[1]);
     std::string y_filename(argv[2]);
 
-    Mat2D X_orig  = read_matrix_file(x_filename);
-    Mat2D Y_orig  = read_matrix_file(y_filename);
-
-    Mat2D X = colwise_z_scores( X_orig );
-    Mat2D Y = colwise_z_scores( Y_orig );
+    Mat2D X = colwise_z_scores( read_matrix_file(x_filename) );
+    Mat2D Y = colwise_z_scores( read_matrix_file(y_filename) );
 
     const size_t ncomp = atoi(argv[3]);
 


### PR DESCRIPTION
These revisions separate out forward declaring vs using the Eigen types.

The Eigen all-header conceit is actually a bit heavy when it comes to include / compile. By manually pre-declaring only what's needed (in the proposed `pls/types.h`), there can be relatively thin header files.

Eigen still needs to be included to actually instantiate any objects. This also has the effect of meaning that class definition can't depend on e.g. the size of objects of that type, which means using pointers / references for fields of the Eigen types.

This also means that downstream stuff using PLS will need to include Eigen explicitly if using Eigen methods, rather than getting everything from including (bloated) pls headers.